### PR TITLE
Add an optional way to define another command for forced shutdowns

### DIFF
--- a/minecraft-server-hibernation.go
+++ b/minecraft-server-hibernation.go
@@ -52,10 +52,13 @@ type basic struct {
 	ServerFileName                string
 	StartMinecraftServerLin       string
 	StopMinecraftServerLin        string
+	ForceStopMinecraftServerLin   string
 	StartMinecraftServerWin       string
 	StopMinecraftServerWin        string
+	ForceStopMinecraftServerWin   string
 	StartMinecraftServerMac       string
 	StopMinecraftServerMac        string
+	ForceStopMinecraftServerMac   string
 	HibernationInfo               string
 	StartingInfo                  string
 	MinecraftServerStartupTime    int
@@ -271,11 +274,23 @@ func stopEmptyMinecraftServer(forceExec bool) {
 	// block that execute the correct stop command depending on the OS
 	var err error
 	if runtime.GOOS == "linux" {
-		err = exec.Command("/bin/bash", "-c", config.Basic.StopMinecraftServerLin).Run()
+		if forceExec {
+			err = exec.Command("/bin/bash", "-c", config.Basic.ForceStopMinecraftServerLin).Run()
+		} else {
+			err = exec.Command("/bin/bash", "-c", config.Basic.StopMinecraftServerLin).Run()
+		}
 	} else if runtime.GOOS == "darwin" {
-		err = exec.Command("/bin/bash", "-c", config.Basic.StopMinecraftServerMac).Run()
+		if forceExec {
+			err = exec.Command("/bin/bash", "-c", config.Basic.ForceStopMinecraftServerMac).Run()
+		} else {
+			err = exec.Command("/bin/bash", "-c", config.Basic.StopMinecraftServerMac).Run()
+		}
 	} else if runtime.GOOS == "windows" {
-		_, err = cmdIn.Write([]byte(config.Basic.StopMinecraftServerWin))
+		if forceExec {
+			_, err = cmdIn.Write([]byte(config.Basic.ForceStopMinecraftServerWin))
+		} else {
+			_, err = cmdIn.Write([]byte(config.Basic.StopMinecraftServerWin))
+		}
 		cmdIn.Close()
 	}
 

--- a/minecraft-server-hibernation.go
+++ b/minecraft-server-hibernation.go
@@ -736,6 +736,17 @@ func initVariables() {
 	if _, err := os.Stat(userIconPath); !os.IsNotExist(err) {
 		loadIcon(userIconPath)
 	}
+
+	// Set force command to normal stop command if undefined
+	if config.Basic.ForceStopMinecraftServerLin == "" {
+		config.Basic.ForceStopMinecraftServerLin = config.Basic.StopMinecraftServerLin
+	}
+	if config.Basic.ForceStopMinecraftServerMac == "" {
+		config.Basic.ForceStopMinecraftServerMac = config.Basic.StopMinecraftServerMac
+	}
+	if config.Basic.ForceStopMinecraftServerWin == "" {
+		config.Basic.ForceStopMinecraftServerWin = config.Basic.StopMinecraftServerWin
+	}
 }
 
 func loadIcon(userIconPath string) {


### PR DESCRIPTION
A naive approach to the functionality discussed [here](https://github.com/gekigek99/minecraft-server-hibernation/issues/51#issuecomment-755784859).  An example of use (well, that’s the way I’m using it) is to add a delay and a warning in case of a forced shutdown, in case players are logged in (and keep no delay when it’s a normal stop because there is no player).

I don’t tested on Mac and Windows since I don’t have theses systems.

If the force commands aren’t defined, the default is to use the normal stop command.