### PR TITLE
Patched GetInput to stop polling if no input is available

### DIFF
--- a/lib/errco/codes.go
+++ b/lib/errco/codes.go
@@ -89,7 +89,8 @@ const (
 
 	// input package
 
-	COMMAND_INPUT_ERROR   = 0x0007f000 // general error while reading command input
-	COMMAND_UNKNOWN_ERROR = 0x0007f001 // command is unknown
-	READ_INPUT_ERROR      = 0x0007f001 // error while reading input)
+	COMMAND_INPUT_ERROR     = 0x0007f000 // general error while reading command input
+	COMMAND_UNKNOWN_ERROR   = 0x0007f001 // command is unknown
+	READ_INPUT_ERROR        = 0x0007f002 // error while reading input)
+	INPUT_UNAVAILABLE_ERROR = 0x0007f003 // stdin is not available
 )

--- a/lib/input/input.go
+++ b/lib/input/input.go
@@ -2,6 +2,7 @@ package input
 
 import (
 	"bufio"
+	"io"
 	"os"
 	"strings"
 
@@ -20,6 +21,10 @@ func GetInput() {
 	for {
 		line, err = reader.ReadString('\n')
 		if err != nil {
+			if err == io.EOF {
+				errco.Logln(errco.LVL_B, "input unavailable, stop listening...")
+				return
+			}
 			errco.LogMshErr(errco.NewErr(errco.READ_INPUT_ERROR, errco.LVL_D, "GetInput", err.Error()))
 			continue
 		}

--- a/lib/input/input.go
+++ b/lib/input/input.go
@@ -24,7 +24,9 @@ func GetInput() {
 			// if stdin is unavailable (msh running as service)
 			// exit from input goroutine to avoid an infinite loop
 			if err == io.EOF {
-				errco.LogMshErr(errco.NewErr(errco.INPUT_UNAVAILABLE_ERROR, errco.LVL_D, "GetInput", "stdin unavailable, exiting input goroutine"))
+				// in case input goroutine returns abnormally while msh is running in terminal,
+				// the user must be notified with errco.LVL_B
+				errco.LogMshErr(errco.NewErr(errco.INPUT_UNAVAILABLE_ERROR, errco.LVL_B, "GetInput", "stdin unavailable, exiting input goroutine"))
 				return
 			}
 			errco.LogMshErr(errco.NewErr(errco.READ_INPUT_ERROR, errco.LVL_D, "GetInput", err.Error()))

--- a/lib/input/input.go
+++ b/lib/input/input.go
@@ -21,8 +21,10 @@ func GetInput() {
 	for {
 		line, err = reader.ReadString('\n')
 		if err != nil {
+			// if stdin is unavailable (msh running as service)
+			// exit from input goroutine to avoid an infinite loop
 			if err == io.EOF {
-				errco.Logln(errco.LVL_B, "input unavailable, stop listening...")
+				errco.LogMshErr(errco.NewErr(errco.INPUT_UNAVAILABLE_ERROR, errco.LVL_D, "GetInput", "stdin unavailable, exiting input goroutine"))
 				return
 			}
 			errco.LogMshErr(errco.NewErr(errco.READ_INPUT_ERROR, errco.LVL_D, "GetInput", err.Error()))


### PR DESCRIPTION
Fixes #121

It fixes the issue by stopping the polling for input when an EOF error occurs.